### PR TITLE
Reconnect exponential backoff

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# [1.1.0](https://github.com/dpatty/eventsource/compare/v1.0.8...v1.1.0)
+* Allow configuring of the reconnection interval using an exponential backoff ([#126](https://github.com/EventSource/eventsource/pull/126) David Patty)
+
+# [1.0.8](https://github.com/dpatty/eventsource/compare/v1.0.7...v1.0.8)
+* Prevent simultaneous reconnection attempts on multiple errors ([#125](https://github.com/EventSource/eventsource/pull/125) David Patty)
+
 # [1.0.7](https://github.com/EventSource/eventsource/compare/v1.0.6...v1.0.7)
 
 * Add dispatchEvent to EventSource ([#101](https://github.com/EventSource/eventsource/pull/101) Ali Afroozeh)

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -44,7 +44,7 @@ function EventSource (url, eventSourceInitDict) {
   })
 
   var self = this
-  self.reconnectInterval = 1000
+  self.reconnectInterval = startingReconnectInterval
   self.connectionInProgress = false
 
   function onConnectionClosed (message) {
@@ -65,6 +65,13 @@ function EventSource (url, eventSourceInitDict) {
       self.connectionInProgress = true
       connect()
     }, self.reconnectInterval)
+
+    increaseReconnectInterval()
+  }
+
+  function increaseReconnectInterval () {
+    self.reconnectInterval *= reconnectIntervalBackoffMultiple
+    self.reconnectInterval = Math.min(maxReconnectInterval, self.reconnectInterval)
   }
 
   var req
@@ -133,7 +140,9 @@ function EventSource (url, eventSourceInitDict) {
     }
 
     req = (isSecure ? https : http).request(options, function (res) {
+      // release the lock on making connections
       self.connectionInProgress = false
+
       // Handle HTTP errors
       if (res.statusCode === 500 || res.statusCode === 502 || res.statusCode === 503 || res.statusCode === 504) {
         _emit('error', new Event('error', {status: res.statusCode, message: res.statusMessage}))
@@ -160,6 +169,9 @@ function EventSource (url, eventSourceInitDict) {
       }
 
       readyState = EventSource.OPEN
+      // reset reconnect interval now that we've actually made a connection
+      self.reconnectInterval = startingReconnectInterval
+
       res.on('close', function () {
         res.removeAllListeners('close')
         res.removeAllListeners('end')
@@ -349,6 +361,25 @@ EventSource.prototype.CLOSED = 2
  */
 EventSource.prototype.close = function () {
   this._close()
+}
+
+// set defaults to 30s max, and exponentially back off @ 2^n
+var startingReconnectInterval = 1000
+var maxReconnectInterval = 1000 * 30
+var reconnectIntervalBackoffMultiple = 2
+// setMaxReconnectInterval allows consumers to configure the max reconnect interval, and the backoff
+EventSource.prototype.setupReconnectInterval = function (starting, max, multiple) {
+  if (Number.isInteger(starting) && starting >= 0) {
+    startingReconnectInterval = starting
+  }
+  if (Number.isInteger(max) && max >= 0) {
+    maxReconnectInterval = max
+  }
+  if (Number.isFinite(multiple) && multiple > 0) {
+    reconnectIntervalBackoffMultiple = multiple
+  }
+
+  this.reconnectInterval = startingReconnectInterval
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventsource",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
   "keywords": [
     "eventsource",

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -885,7 +885,7 @@ describe('Reconnection', function () {
           var fn = writeEvents(events)
           fn(req, res)
           eventsSent++
-          // now cause a parse error!
+          // now cause a few errors
           fn(req, res)
           eventsSent++
         } else {
@@ -899,7 +899,6 @@ describe('Reconnection', function () {
       assert.equal(EventSource.CONNECTING, es.readyState)
       es.reconnectInterval = 0
       es.onerror = function (err) {
-        console.log(err);
         errorOccurred = !!(errorOccurred || err)
       }
     })


### PR DESCRIPTION
Make the error state retry reconnection on an exponentially increasing interval. 
I made the starting interval, the maximum interval and the exponential multiple all configurable via `EventSource.setupReconnectInterval`

![Exponential backoff](https://user-images.githubusercontent.com/1545395/60364488-8f099680-99a3-11e9-8d73-5b52b576db9d.png)

Bump to version 1.1.0